### PR TITLE
✨ 変更を行ったファイルのパスのみをブラウザで開く機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *
 
 !.gitignore
+!bin/
+!bin/**
 !LICENSE
 !Makefile
 !README.md

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,12 @@ open:
 	else \
 		echo "Output file not found: output/php-chunked-xhtml/index.html"; \
 	fi
+
+open-modified:
+	PATHS=`php bin/getModifiedFilePath.php`; \
+	\
+	if [ -n "$$PATHS" ]; then \
+		open $$PATHS; \
+	else \
+		echo "Modified file not found"; \
+	fi

--- a/bin/getModifiedFilePath.php
+++ b/bin/getModifiedFilePath.php
@@ -1,0 +1,90 @@
+<?php
+
+const LANG = 'ja';
+
+main();
+
+/**
+ * LANG配下のgit-statusより更新されたファイルを取得し対応するHTMLファイルのパスを出力
+ *
+ * @return string[]
+ */
+function main(): void
+{
+    $gitStatusOutput = getGitStatusOutput(LANG);
+
+    $modifiedFiles = array_filter(
+        getModifiedFilesFromGitStatusOutput($gitStatusOutput),
+        fn (string $file) => str_ends_with($file, '.xml'),
+    );
+
+    $pageIds = array_filter(array_map(
+        fn (string $file) => getPageIdFromFile(LANG . '/' . $file),
+        $modifiedFiles,
+    ));
+
+    $pathes = array_map(
+        fn (string $id) => "output/php-chunked-xhtml/{$id}.html",
+        $pageIds,
+    );
+
+    echo implode("\n", $pathes) . PHP_EOL;
+}
+
+/**
+ * 指定されたパスの git-status を取得
+ */
+function getGitStatusOutput(string $path): string
+{
+    return `git -C {$path} status --porcelain=1`;
+}
+
+/**
+ * git-status の出力より更新されたファイルの一覧を取得
+ *
+ * @return string[]
+ */
+function getModifiedFilesFromGitStatusOutput(string $output): array
+{
+    $files = [];
+
+    foreach (explode("\n", $output) as $line) {
+        $status = substr($line, 0, 2);
+        $file = substr($line, 3);
+
+        if (!in_array($status, [
+            '??', // 新規の未追跡ファイル（Untracked）
+            'A ', // インデックスに追加された新規ファイル（Added to index）
+            'M ', // インデックスが修正されたファイル（Modified in index）
+            'AM', // インデックスに追加され、ワーキングディレクトリでも変更されたファイル
+            'MM', // インデックスが修正され、ワーキングディレクトリでも修正されたファイル
+            'RM', // インデックスでリネームされ、ワーキングディレクトリで修正されたファイル
+            'CM', // インデックスでコピーされ、ワーキングディレクトリで修正されたファイル
+            ' M', // ワーキングディレクトリで変更されたファイル（Modified in working tree）
+        ])) {
+            continue;
+        }
+
+        $files[] = preg_match('/^\S+ -> (\S+)$/', $file, $matches)
+            ? $matches[1]
+            : $file;
+    }
+
+    return $files;
+}
+
+function getPageIdFromFile(string $file): ?string
+{
+    $xml = new XMLReader();
+    $xml->open($file);
+
+    while ($xml->nodeType !== XMLReader::ELEMENT) {
+        if (!@$xml->read()) {
+            return null;
+        }
+    }
+
+    $id = $xml->getAttribute('xml:id');
+
+    return $id;
+}


### PR DESCRIPTION
closes #1 

簡易的な実装のため制限がありますが、変更対象に *ある程度近い* ページをブラウザで開くためのスクリプトとmakeターゲットを作成しました。

* `doc-base`, `phd` の機能としては（おそらく）提供されていないため `git status` コマンドの出力をパースすることで変更対象を検出する実装としました。
* 1つのxmlファイルが複数のページを出力するケースがあるため次のような仕様としました:
  * 更新対象のxmlの最上位のページを開く
  * 例えば [言語リファレンス / 関数 / ユーザー定義関数](https://www.php.net/manual/ja/functions.user-defined.php) を更新した場合も開かれるパスは [言語リファレンス / 関数](https://www.php.net/manual/ja/language.functions.php) になる
  * この例の場合、何れも元ファイルは `language/functions.xml`
  * （xmlファイルの内容までパースすれば更新ページを正確に特定するのは、不可能ではないが少し難しい）
* `open` とは別で `open-modified` ターゲットを新設
  * 上の通り、現時点で完全な実装ではないため
  * テストなども不足しているため

DocBookの仕様にあまり詳しくないため、追加したphpスクリプトの実装が想定していないxmlだった場合は誤動作するかもしれません。

極めて簡易的な実装のため、使い勝手良くない点やMakefileの仕様などはご自由にカスタマイズしてください。用途に合わない場合はクローズ頂いても大丈夫です。 *Allow edits by maintainers* はオンにしました。
